### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/carto/colormap.go
+++ b/carto/colormap.go
@@ -218,7 +218,7 @@ func (c *ColorMap) getColorOnLegend(gradLoc, barLeft,
 	panic("Problem getting color")
 }
 
-// get color for input value. Must run c.Set() first.
+// GetColor gets color for input value. Must run c.Set() first.
 func (cm *ColorMap) GetColor(v float64) color.NRGBA {
 	var R, G, B uint8
 	c := cm.stopcolors

--- a/index/rtree/rtree.go
+++ b/index/rtree/rtree.go
@@ -417,7 +417,7 @@ func (tree *Rtree) condenseTree(n *node) {
 
 // Searching
 
-// SearchIntersectBB returns all objects that intersect the specified rectangle.
+// SearchIntersect returns all objects that intersect the specified rectangle.
 //
 // Implemented per Section 3.1 of "R-trees: A Dynamic Index Structure for
 // Spatial Searching" by A. Guttman, Proceedings of ACM SIGMOD, p. 47-57, 1984.


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?